### PR TITLE
スクロールアクションの修正

### DIFF
--- a/src/card.css
+++ b/src/card.css
@@ -26,6 +26,10 @@
       max-width: 100%;
       border-radius: 10px;
     }
+
+    .vis-hidden {
+      visibility: hidden;
+    }
   
     .description {
       width: 35%;
@@ -64,6 +68,10 @@
       height: 220px;
       max-width: 100%;
       border-radius: 10px;
+    }
+
+    .vis-hidden {
+      visibility: hidden;
     }
   
     .description {
@@ -108,6 +116,10 @@
       height: 350px;
       max-width: 100%;
       border-radius: 10px;
+    }
+
+    .vis-hidden {
+      visibility: hidden;
     }
   
     .description {


### PR DESCRIPTION
スクロールアクションが起こる前に、既にコンテンツが表示されていた問題を解決
-NotInView時、コンテンツのclassはvis-hiddenだから、cssにvis-hiddenを追加し、内容を隠した
